### PR TITLE
Add basic homeflag impl and update action ids

### DIFF
--- a/pybambu/const.py
+++ b/pybambu/const.py
@@ -19,7 +19,8 @@ class Features(Enum):
     AMS_TEMPERATURE = 11,
     CAMERA_RTSP = 13,
     START_TIME_GENERATED = 14,
-    CAMERA_IMAGE = 15
+    CAMERA_IMAGE = 15,
+    DOOR_SENSOR = 16
 
 
 class FansEnum(Enum):
@@ -52,6 +53,20 @@ ACTION_IDS = {
     19: "calibrating_extrusion_flow",
     20: "paused_nozzle_temperature_malfunction",
     21: "paused_heat_bed_temperature_malfunction",
+    22: "filament unloading",
+    23: "paused_skipped_step",
+    24: "filament_loading",
+    25: "calibrating_motor_noise",
+    26: "paused_ams_lost",
+    27: "paused_low_fan_speed_heat_break",
+    28: "paused_chamber_temperature_control_error",
+    29: "cooling_chamber",
+    30: "paused_user_gcode",
+    31: "motor_noise_showoff",
+    32: "paused_nozzle_filament_covered_detected",
+    33: "paused_cutter_error",
+    34: "paused_first_layer_error",
+    35: "paused_nozzle_clog",
     # X1 returns -1 for idle
     -1: "idle",
     # P1 returns 255 for idle
@@ -115,6 +130,10 @@ FILAMENT_NAMES = {
     "GFL03": "eSUN PLA+",
     "GFSL99_01": "Generic PLA Silk",
     "GFSL99_12": "Generic PLA Silk",
+    "GFA12": "Bambu PLA Glow",
+    "GFT97": "Generic PPS",
+    "GFT98": "Generic PPS-CF",
+    "GFU00": "Bambu TPU 95A HF",
 }
 
 HMS_ERRORS = {

--- a/pybambu/models.py
+++ b/pybambu/models.py
@@ -55,7 +55,7 @@ class Device:
         self.external_spool.print_update(data)
         self.hms.print_update(data)
         self.camera.print_update(data)
-        self.home_flag.print_update(data=data, info=self.info)
+        self.home_flag.print_update(data=data)
         if self.client.callback is not None:
             self.client.callback("event_printer_data_update")
 
@@ -66,6 +66,7 @@ class Device:
     def info_update(self, data):
         """Update from dict"""
         self.info.info_update(data)
+        self.home_flag.info_update(info=self.info)
         self.ams.info_update(data)
         if data.get("command") == "get_version":
             self.get_version_data = data
@@ -862,9 +863,11 @@ class HomeFlag:
         self.device_type = device_type
         self.sw_ver = "unknown"
 
-    def print_update(self, data: dict, info: Info = None):
+    def info_update(self, info: Info = None):
         if info is not None:
             self.sw_ver = info.sw_ver
+
+    def print_update(self, data: dict):
         if "homeflag" in data:
             value = int(data.get("homeflag"))
             if value != self.value:

--- a/pybambu/models.py
+++ b/pybambu/models.py
@@ -882,7 +882,8 @@ class HomeFlag:
             return "none"
 
         elif (self.sw_ver == "unknown" or
-              (self.device_type.startswith("X1") and version.parse(self.sw_ver) < version.parse("01.07.00.00"))):
+                # X1E has different firmware versioning than X1/X1C
+              (self.device_type in ["X1", "X1C"] and version.parse(self.sw_ver) < version.parse("01.07.00.00"))):
             return "unknown"
 
         return "open" if ((self.value >> 23) & 0x1) == 1 else "closed"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+required = ["paho-mqtt", "packaging"]
+
 setuptools.setup(
     name="pybambu",
     version="1.0.0",
@@ -12,7 +14,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/greghesp/pybambu",
-    REQUIRED=["paho-mqtt"],
+    install_requires=required,
+    REQUIRED=required,
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Added basic homeflag implementation for parsing basic values
- Updated action id's with new recent additions
- Added a few filaments missing from HA-Bambulab port
- Updated push_all data setting due to new X1 firmware
- Fixed setup.py requirements 
- Added packaging package to enable firmware versioning checks for future use (see door-sensor)

Will merge into a develop branch once it is created. Main branch should ideally be whatever is recent pushed version to pip with appropriate version number changes. Currently is set to main - will edit once made.