### PR TITLE
Add more HMS Notification properties

### DIFF
--- a/pybambu/const.py
+++ b/pybambu/const.py
@@ -138,6 +138,7 @@ FILAMENT_NAMES = {
     "GFU00": "Bambu TPU 95A HF",
 }
 
+# TODO: Update error lists with data from https://e.bambulab.com/query.php?lang=en
 HMS_ERRORS = {
     "0300_1000_0002_0001": "The 1st order mechanical resonance mode of X axis is low.",
     "0300_1000_0002_0002": "The 1st order mechanical resonance mode of X axis differ much...",
@@ -253,6 +254,24 @@ HMS_AMS_ERRORS = {
     "0700_2000_0003_0002": "AMS1 slot 1 filament has run out and automatically switched to the slot with the same filament.",
     "0700_6000_0002_0001": "AMS1 slot 1 is overloaded. The filament may be tangled or the spool may be stuck.",
 }
+
+HMS_SEVERITY_LEVELS = {
+    "default": "unknown",
+    1: "fatal",
+    2: "serious",
+    3: "common",
+    4: "info"
+}
+
+HMS_MODULES = {
+    "default": "unknown",
+    0x05: "mainboard",
+    0x0C: "xcam",
+    0x07: "ams",
+    0x08: "toolhead",
+    0x03: "mc"
+}
+
 
 class SdcardState(Enum):
     NO_SDCARD                           = 0x00000000,

--- a/pybambu/models.py
+++ b/pybambu/models.py
@@ -1068,8 +1068,8 @@ class HMSList:
             index: int = 0
             for hms in hmsList:
                 index = index + 1
-                attr = hms['attr']
-                code = hms['code']
+                attr = int(hms['attr'])
+                code = int(hms['code'])
                 hms_notif = HMSNotification(attr=attr, code=code)
                 errors[f"{index}-Error"] = f"HMS_{hms_notif.hms_code}: {get_HMS_error_text(hms_notif.hms_code)}"
                 errors[f"{index}-Wiki"] = hms_notif.wiki_url

--- a/pybambu/models.py
+++ b/pybambu/models.py
@@ -18,8 +18,10 @@ from .utils import \
     get_start_time, \
     get_end_time, \
     get_HMS_error_text, \
-    get_generic_AMS_HMS_error_code
-    
+    get_generic_AMS_HMS_error_code, \
+    get_HMS_severity, \
+    get_HMS_module
+
 from .const import LOGGER, Features, FansEnum, Home_Flag_Values, SdcardState, SPEED_PROFILE
 from .commands import CHAMBER_LIGHT_ON, CHAMBER_LIGHT_OFF, SPEED_PROFILE_TEMPLATE
 
@@ -1068,9 +1070,11 @@ class HMSList:
                 index = index + 1
                 attr = hms['attr']
                 code = hms['code']
-                hms_error = f'{int(attr / 0x10000):0>4X}_{attr & 0xFFFF:0>4X}_{int(code / 0x10000):0>4X}_{code & 0xFFFF:0>4X}'  # 0300_0100_0001_0007
-                errors[f"{index}-Error"] = f"HMS_{hms_error}: {get_HMS_error_text(hms_error)}"
-                errors[f"{index}-Wiki"] = f"https://wiki.bambulab.com/en/x1/troubleshooting/hmscode/{get_generic_AMS_HMS_error_code(hms_error)}"
+                hms_notif = HMSNotification(attr=attr, code=code)
+                errors[f"{index}-Error"] = f"HMS_{hms_notif.hms_code}: {get_HMS_error_text(hms_notif.hms_code)}"
+                errors[f"{index}-Wiki"] = hms_notif.wiki_url
+                errors[f"{index}-Severity"] = hms_notif.severity
+                #errors[f"{index}-Module"] = hms_notif.module # commented out to avoid bloat with current structure
 
             if self.errors != errors:
                 self.errors = errors
@@ -1081,6 +1085,36 @@ class HMSList:
                 return True
         
         return False
+
+
+@dataclass
+class HMSNotification:
+    """Return an HMS object and all associated details"""
+
+    def __init__(self, attr: int = 0, code: int = 0):
+        self.attr = attr
+        self.code = code
+
+    @property
+    def severity(self):
+        return get_HMS_severity(self.code)
+
+    @property
+    def module(self):
+        return get_HMS_module(self.attr)
+
+    @property
+    def hms_code(self):
+        if self.attr > 0 and self.code > 0:
+            return f'{int(self.attr / 0x10000):0>4X}_{self.attr & 0xFFFF:0>4X}_{int(self.code / 0x10000):0>4X}_{self.code & 0xFFFF:0>4X}' # 0300_0100_0001_0007
+        return ""
+
+    @property
+    def wiki_url(self):
+        if self.attr > 0 and self.code > 0:
+            return f"https://wiki.bambulab.com/en/x1/troubleshooting/hmscode/{get_generic_AMS_HMS_error_code(self.hms_code)}"
+        return ""
+
 
 @dataclass
 class ChamberImage:

--- a/pybambu/utils.py
+++ b/pybambu/utils.py
@@ -1,7 +1,8 @@
 import math
 from datetime import datetime, timedelta
 
-from .const import ACTION_IDS, SPEED_PROFILE, FILAMENT_NAMES, HMS_ERRORS, HMS_AMS_ERRORS, LOGGER, FansEnum
+from .const import (ACTION_IDS, SPEED_PROFILE, FILAMENT_NAMES, HMS_ERRORS, HMS_AMS_ERRORS, LOGGER, FansEnum,
+                    HMS_SEVERITY_LEVELS, HMS_MODULES)
 from .commands import SEND_GCODE_TEMPLATE
 
 
@@ -75,6 +76,21 @@ def get_HMS_error_text(hms_code: str):
         return ams_error
 
     return HMS_ERRORS.get(hms_code, "unknown")
+
+
+def get_HMS_severity(code: int) -> str:
+    uint_code = code >> 16
+    if code > 0 and uint_code in HMS_SEVERITY_LEVELS:
+        return HMS_SEVERITY_LEVELS[uint_code]
+    return HMS_SEVERITY_LEVELS["default"]
+
+
+def get_HMS_module(attr: int) -> str:
+    uint_attr = (attr >> 24) & 0xFF
+    if attr > 0 and uint_attr in HMS_MODULES:
+        return HMS_MODULES[uint_attr]
+    return HMS_MODULES["default"]
+
 
 def get_generic_AMS_HMS_error_code(hms_code: str):
     code1 = int(hms_code[0:4], 16)


### PR DESCRIPTION
Adds new HMS Notification object that enables parsing the severity and module from the error. Minimally just adds severity to the errors list, but creates setup for future additions for handling different types of HMS notifs.